### PR TITLE
Fix indentation bug in analyzer

### DIFF
--- a/android_log_analyzer/log_analyzer.py
+++ b/android_log_analyzer/log_analyzer.py
@@ -264,7 +264,7 @@ def analyze_native_crash_hint(log_entry):
             # Only return if a specific detail (like signal or process info) was actually extracted.
             # This avoids flagging generic lines from DEBUG/libc tags as native crashes without more evidence.
             if found_specific_detail:
-                 return extracted_data
+                return extracted_data
     return None
 
 


### PR DESCRIPTION
## Summary
- fix wrong indentation in `analyze_native_crash_hint`

## Testing
- `python -m unittest android_log_analyzer.test_log_analyzer -v`

------
https://chatgpt.com/codex/tasks/task_e_6843b2eb5508832782451a4ecb250919