### PR TITLE
Improve log analyzer - directory and zip support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ pip install -e .
 android-log-analyzer path/to/logcat.log
 ```
 
+You can also provide a directory instead of a single file. The analyzer
+will recursively scan for `.log`, `.txt`, `.gz` and `.zip` files.
+
 To also save the results as JSON, specify an output file:
 
 ```bash

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -11,6 +11,8 @@ pip install -e .
 android-log-analyzer path/to/logcat.log
 ```
 
+同样可以传入目录路径，工具会递归扫描其中的 `.log`、`.txt`、`.gz` 和 `.zip` 文件。
+
 如需将结果保存为 JSON，可指定输出文件：
 ```bash
 android-log-analyzer path/to/logcat.log --json-output report.json


### PR DESCRIPTION
## Summary
- support gzip/zip logs and directories
- document new behavior in README and README_zh-CN
- update CLI help and analyzer logic
- add tests for compressed file and recursive directory reading

## Testing
- `python -m unittest android_log_analyzer.test_log_analyzer -v`

------
https://chatgpt.com/codex/tasks/task_e_6843b95c2cd0832789113996e4ab3808